### PR TITLE
Add Enum support

### DIFF
--- a/src/cap_controls.jl
+++ b/src/cap_controls.jl
@@ -81,12 +81,13 @@ module CapControls
     end
 
     """Type of automatic controller. (Getter)"""
-    function Mode()::Int
+    function Mode()::Lib.CapControlModes
         return Lib.CapControls_Get_Mode()
     end
 
     """Type of automatic controller. (Setter)"""
-    function Mode(Value::Int)
+    function Mode(Value::Union{Int, Lib.CapControlModes})
+        Value = convert(Lib.CapControlModes, Value)
         Lib.CapControls_Set_Mode(Value)
     end
 

--- a/src/ctrl_queue.jl
+++ b/src/ctrl_queue.jl
@@ -36,8 +36,7 @@ module CtrlQueue
     end
 
     """Code for the active action. Long integer code to tell the control device what to do"""
-    function ActionCode()::Int
-        # TODO: return enum?
+    function ActionCode()::Lib.ActionCodes
         return Lib.CtrlQueue_Get_ActionCode()
     end
 

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -32,22 +32,32 @@ module Lib
         SolveModes_Harmonic = 15,
         SolveModes_Dynamic = 14,
     )
-    @cenum(Options,
-        Options_PowerFlow = 1,
-        Options_Admittance = 2,
-        Options_NormalSolve = 0,
-        Options_NewtonSolve = 1,
-        Options_Static = 0,
-        Options_Event = 1,
-        Options_Time = 2,
-        Options_Multiphase = 0,
-        Options_PositiveSeq = 1,
-        Options_Gaussian = 1,
-        Options_Uniform = 2,
-        Options_LogNormal = 3,
-        Options_AddGen = 1,
-        Options_AddCap = 2,
-        Options_ControlOFF = 4294967295,
+    @cenum(SolutionLoadModels,
+        SolutionLoadModels_PowerFlow = 1,
+        SolutionLoadModels_Admittance = 2,
+    )
+    @cenum(SolutionAlgorithms,
+        SolutionAlgorithms_NormalSolve = 0,
+        SolutionAlgorithms_NewtonSolve = 1,
+    )
+    @cenum(ControlModes,
+        ControlModes_Static = 0,
+        ControlModes_Event = 1,
+        ControlModes_Time = 2,
+        ControlModes_ControlOff = 4294967295,
+    )
+    @cenum(CktModels,
+        CktModels_Multiphase = 0,
+        CktModels_PositiveSeq = 1,
+    )
+    @cenum(RandomModes,
+        RandomModes_Gaussian = 1,
+        RandomModes_Uniform = 2,
+        RandomModes_LogNormal = 3
+    )
+    @cenum(AutoAddTypes,
+        AutoAddTypes_AddGen = 1,
+        AutoAddTypes_AddCap = 2,
     )
     @cenum(CapControlModes,
         CapControlModes_Voltage = 1,

--- a/src/lines.jl
+++ b/src/lines.jl
@@ -237,12 +237,13 @@ module Lines
     end
 
     """Units for Line (Getter)"""
-    function Units()::Int
+    function Units()::Lib.LineUnits
         return Lib.Lines_Get_Units()
     end
 
     """Units for Line (Setter)"""
-    function Units(Value::Int)
+    function Units(Value::Union{Int, Lib.LineUnits})
+        Value = convert(Lib.LineUnits, Value)
         Lib.Lines_Set_Units(Value)
     end
 

--- a/src/loads.jl
+++ b/src/loads.jl
@@ -106,12 +106,13 @@ module Loads
     end
 
     """The Load Model defines variation of P and Q with voltage. (Getter)"""
-    function Model()::Int
+    function Model()::Lib.LoadModels
         return Lib.Loads_Get_Model()
     end
 
     """The Load Model defines variation of P and Q with voltage. (Setter)"""
-    function Model(Value::Int)
+    function Model(Value::Union{Int, Lib.LoadModels})
+        Value = convert(Lib.LoadModels, Value)
         Lib.Loads_Set_Model(Value)
     end
 
@@ -201,12 +202,13 @@ module Loads
     end
 
     """Response to load multipliers: Fixed (growth only), Exempt (no LD curve), Variable (all). (Getter)"""
-    function Status()::Int
+    function Status()::Lib.LoadStatus
         return Lib.Loads_Get_Status()
     end
 
     """Response to load multipliers: Fixed (growth only), Exempt (no LD curve), Variable (all). (Setter)"""
-    function Status(Value::Int)
+    function Status(Value::Union{Int, Lib.LoadStatus})
+        Value = convert(Lib.LoadStatus, Value)
         Lib.Loads_Set_Status(Value)
     end
 

--- a/src/monitors.jl
+++ b/src/monitors.jl
@@ -104,12 +104,13 @@ module Monitors
     end
 
     """Set Monitor mode (bitmask integer - see DSS Help)"""
-    function Mode()::Int
+    function Mode()::Lib.MonitorModes
         return Lib.Monitors_Get_Mode()
     end
 
     """Set Monitor mode (bitmask integer - see DSS Help)"""
-    function Mode(Value::Int)
+    function Mode(Value::Union{Int, Lib.MonitorModes})
+        Value = convert(Lib.MonitorModes, Value)
         Lib.Monitors_Set_Mode(Value)
     end
 

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -31,12 +31,13 @@ module Settings
     end
 
     """{dssMultiphase * | dssPositiveSeq} IIndicate if the circuit model is positive sequence. (Getter)"""
-    function CktModel()::Int
+    function CktModel()::Lib.CktModels
         return Lib.Settings_Get_CktModel()
     end
 
     """{dssMultiphase * | dssPositiveSeq} IIndicate if the circuit model is positive sequence. (Setter)"""
-    function CktModel(Value::Int)
+    function CktModel(Value::Union{Int, Lib.CktModels})
+        Value = convert(Lib.CktModels, Value)
         Lib.Settings_Set_CktModel(Value)
     end
 

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -86,22 +86,24 @@ module Solution
     end
 
     """Type of device to add in AutoAdd Mode: {dssGen (Default) | dssCap} (Getter)"""
-    function AddType()::Int
+    function AddType()::Lib.AutoAddTypes
         return Lib.Solution_Get_AddType()
     end
 
     """Type of device to add in AutoAdd Mode: {dssGen (Default) | dssCap} (Setter)"""
-    function AddType(Value::Int)
+    function AddType(Value::Union{Int, Lib.AutoAddTypes})
+        Value = convert(Lib.AutoAddTypes, Value)
         Lib.Solution_Set_AddType(Value)
     end
 
     """Base Solution algorithm: {dssNormalSolve | dssNewtonSolve} (Getter)"""
-    function Algorithm()::Int
+    function Algorithm()::Lib.SolutionAlgorithms
         return Lib.Solution_Get_Algorithm()
     end
 
     """Base Solution algorithm: {dssNormalSolve | dssNewtonSolve} (Setter)"""
-    function Algorithm(Value::Int)
+    function Algorithm(Value::Union{Int, Lib.SolutionAlgorithms})
+        Value = convert(Lib.SolutionAlgorithms, Value)
         Lib.Solution_Set_Algorithm(Value)
     end
 
@@ -136,12 +138,13 @@ module Solution
     end
 
     """{dssStatic* | dssEvent | dssTime}  Modes for control devices (Getter)"""
-    function ControlMode()::Int
+    function ControlMode()::Lib.ControlModes
         return Lib.Solution_Get_ControlMode()
     end
 
     """{dssStatic* | dssEvent | dssTime}  Modes for control devices (Setter)"""
-    function ControlMode(Value::Int)
+    function ControlMode(Value::Union{Int, Lib.ControlModes})
+        Value = convert(Lib.ControlModes, Value)
         Lib.Solution_Set_ControlMode(Value)
     end
 
@@ -256,12 +259,13 @@ module Solution
     end
 
     """Load Model: {dssPowerFlow (default) | dssAdmittance}"""
-    function LoadModel()::Int
+    function LoadModel()::Lib.SolutionLoadModels
         return Lib.Solution_Get_LoadModel()
     end
 
     """Load Model: {dssPowerFlow (default) | dssAdmittance}"""
-    function LoadModel(Value::Int)
+    function LoadModel(Value::Union{Int, Lib.SolutionLoadModels})
+        Value = convert(Lib.SolutionLoadModels, Value)
         Lib.Solution_Set_LoadModel(Value)
     end
 
@@ -311,13 +315,14 @@ module Solution
         Lib.Solution_Set_MinIterations(Value)
     end
 
-    """Set present solution mode (by a text code - see DSS Help)"""
-    function Mode()::Int
+    """Get present solution mode (by a text code - see DSS Help)"""
+    function Mode()::Lib.SolveModes
         return Lib.Solution_Get_Mode()
     end
 
     """Set present solution mode (by a text code - see DSS Help)"""
-    function Mode(Value::Int)
+    function Mode(Value::Union{Int, Lib.SolveModes})
+        Value = convert(Lib.SolveModes, Value)
         Lib.Solution_Set_Mode(Value)
     end
 
@@ -346,13 +351,14 @@ module Solution
         return Lib.Solution_Get_Process_Time()
     end
 
-    """Randomization mode for random variables "Gaussian" or "Uniform" """
-    function Random()::Int
+    """Randomization mode for random variables "Gaussian" or "Uniform" (Getter)"""
+    function Random()::Lib.RandomModes
         return Lib.Solution_Get_Random()
     end
 
-    """Gets the time required to perform the latest solution (Read only)"""
-    function ProcessTime(Value::Int)
+    """Randomization mode for random variables "Gaussian" or "Uniform" (Setter)"""
+    function Random(Value::Union{Int, Lib.RandomModes})
+        Value = convert(Lib.RandomModes, Value)
         Lib.Solution_Set_Random(Value)
     end
 

--- a/test/capcontrols.jl
+++ b/test/capcontrols.jl
@@ -7,7 +7,9 @@ init8500()
 @test CapControls.First() == 1
 @test CapControls.Next() == 2
 @test CapControls.Mode() == 2
-@test CapControls.Mode(CapControls.Mode()) == nothing
+@test CapControls.Mode() == OpenDSSDirect.Lib.CapControlModes_KVAR
+@test CapControls.Mode(2) == nothing
+@test CapControls.Mode(OpenDSSDirect.Lib.CapControlModes_KVAR) == nothing
 @test CapControls.MonitoredTerm() == 1
 @test CapControls.MonitoredTerm(CapControls.MonitoredTerm()) == nothing
 @test CapControls.UseVoltOverride()

--- a/test/lines.jl
+++ b/test/lines.jl
@@ -12,7 +12,9 @@ init8500()
 @test Lines.Parent() == 0
 @test Lines.Count() == 3703
 @test Lines.Units() == 3
-@test Lines.Units(Lines.Units()) == nothing
+@test Lines.Units() == OpenDSSDirect.Lib.LineUnits_km
+@test Lines.Units(3) == nothing
+@test Lines.Units(OpenDSSDirect.Lib.LineUnits_km) == nothing
 @test Lines.Length() ≋ 0.032175613
 @test Lines.Length(Lines.Length()) == nothing
 @test Lines.R1() ≋ 0.058

--- a/test/loads.jl
+++ b/test/loads.jl
@@ -12,11 +12,15 @@ init8500()
 @test Loads.Class() == 1
 @test Loads.Class(Loads.Class()) == nothing
 @test Loads.Model() == 1
-@test Loads.Model(Loads.Model()) == nothing
+@test Loads.Model() == OpenDSSDirect.Lib.LoadModels_ConstPQ
+@test Loads.Model(1) == nothing
+@test Loads.Model(OpenDSSDirect.Lib.LoadModels_ConstPQ) == nothing
 @test Loads.NumCust() == 1
 @test Loads.NumCust(Loads.NumCust()) == nothing
 @test Loads.Status() == 0
-@test Loads.Status(Loads.Status()) == nothing
+@test Loads.Status() == OpenDSSDirect.Lib.LoadStatus_Variable
+@test Loads.Status(0) == nothing
+@test Loads.Status(OpenDSSDirect.Lib.LoadStatus_Variable) == nothing
 @test Loads.IsDelta() == false
 @test Loads.IsDelta(Loads.IsDelta()) == nothing
 @test Loads.kW() ≋ 5.84

--- a/test/monitors.jl
+++ b/test/monitors.jl
@@ -16,7 +16,9 @@ OpenDSSDirect.Text.Command("""
 @test Monitors.Save() == nothing
 # @test Monitors.Show() == nothing
 @test Monitors.Mode() == 0
-@test Monitors.Mode(Monitors.Mode()) == nothing
+@test Monitors.Mode() == OpenDSSDirect.Lib.MonitorModes_VI
+@test Monitors.Mode(0) == nothing
+@test Monitors.Mode(OpenDSSDirect.Lib.MonitorModes_VI) == nothing
 @test Monitors.SampleCount() == 0
 @test Monitors.SampleAll() == nothing
 @test Monitors.SaveAll() == nothing

--- a/test/settings.jl
+++ b/test/settings.jl
@@ -9,7 +9,9 @@ init8500()
 @test Settings.ZoneLock() == 0
 @test Settings.ZoneLock(Settings.ZoneLock()) == nothing
 @test Settings.CktModel() == 0
-@test Settings.CktModel(Settings.CktModel()) == nothing
+@test Settings.CktModel() == OpenDSSDirect.Lib.CktModels_Multiphase
+@test Settings.CktModel(0) == nothing
+@test Settings.CktModel(OpenDSSDirect.Lib.CktModels_Multiphase) == nothing
 @test Settings.Trapezoidal() == 0
 @test Settings.Trapezoidal(Settings.Trapezoidal()) == nothing
 @test Settings.AllocationFactors(1.0) == nothing

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -6,7 +6,9 @@ init8500()
 
 @test Solution.Solve() == nothing
 @test Solution.Mode() == 0
-@test Solution.Mode(Solution.Mode()) == nothing
+@test Solution.Mode() == OpenDSSDirect.Lib.SolveModes_SnapShot
+@test Solution.Mode(0) == nothing
+@test Solution.Mode(OpenDSSDirect.Lib.SolveModes_SnapShot) == nothing
 @test Solution.Hour() == 0
 @test Solution.Hour(Solution.Hour()) == nothing
 @test Solution.Year() == 0
@@ -17,15 +19,23 @@ init8500()
 @test Solution.Number() == 1
 @test Solution.Number(Solution.Number()) == nothing
 @test Solution.Random() == 1
-# @test Solution.Random(Solution.Random()) == nothing
+@test Solution.Random() == OpenDSSDirect.Lib.RandomModes_Gaussian
+@test Solution.Random(1) == nothing
+@test Solution.Random(OpenDSSDirect.Lib.RandomModes_Gaussian) == nothing
 @test Solution.LoadModel() == 1
 @test Solution.LoadModel(Solution.LoadModel()) == nothing
 @test Solution.AddType() == 1
-@test Solution.AddType(Solution.AddType()) == nothing
+@test Solution.AddType() == OpenDSSDirect.Lib.AutoAddTypes_AddGen
+@test Solution.AddType(1) == nothing
+@test Solution.AddType(OpenDSSDirect.Lib.AutoAddTypes_AddGen) == nothing
 @test Solution.Algorithm() == 0
-@test Solution.Algorithm(Solution.Algorithm()) == nothing
+@test Solution.Algorithm() == OpenDSSDirect.Lib.SolutionAlgorithms_NormalSolve
+@test Solution.Algorithm(0) == nothing
+@test Solution.Algorithm(OpenDSSDirect.Lib.SolutionAlgorithms_NormalSolve) == nothing
 @test Solution.ControlMode() == 0
-@test Solution.ControlMode(Solution.ControlMode()) == nothing
+@test Solution.ControlMode() == OpenDSSDirect.Lib.ControlModes_Static
+@test Solution.ControlMode(0) == nothing
+@test Solution.ControlMode(OpenDSSDirect.Lib.ControlModes_Static) == nothing
 @test Solution.ControlIterations() == 5
 @test Solution.ControlIterations(Solution.ControlIterations()) == nothing
 @test Solution.MaxControlIterations() == 10


### PR DESCRIPTION
This PR will make certain functions dispatch only on specific values.

```
julia> using OpenDSSDirect

julia> dss("redirect ./test.dss")
""

julia> Solution.Mode()
SolveModes_SnapShot(0)

julia> Solution.Mode(1)

julia> Solution.Mode()
SolveModes_Daily(1)

julia> Solution.Mode(OpenDSSDirect.Lib.SolveModes_Harmonic)

julia> Solution.Mode()
SolveModes_Harmonic(15)

julia> Solution.Mode(200)
ERROR: ArgumentError: invalid value for Enum SolveModes: 200
Stacktrace:
 [1] enum_argument_error(::Symbol, ::Int64) at ./Enums.jl:29
 [2] convert at /Users/$USER/GitRepos/OpenDSSDirect.jl/src/CEnum.jl:103 [inlined]
 [3] Mode(::Int64) at /Users/$USER/GitRepos/OpenDSSDirect.jl/src/solution.jl:321
 [4] top-level scope at none:0

help?> Solution.Mode
  Mode()::OpenDSSDirect.Lib.SolveModes



  Get present solution mode (by a text code - see DSS Help)

  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────

  Mode(Value::Union{Int64, SolveModes})



  Set present solution mode (by a text code - see DSS Help)

julia>
```