### PR TITLE
Add download examples function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/site/
 *.csv
 deps/*
 !deps/build.jl
+examples/electricdss-tst-master/*

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -60,7 +60,7 @@ function download(::Type{Windows})
     directory = normpath(@__DIR__)
     mkpath(directory)
 
-    home = (VERSION < v"0.7-") ? JULIA_HOME : Sys.BINDIR
+    home = (Base.VERSION < v"0.7-") ? JULIA_HOME : Sys.BINDIR
     success(`$home/7z x $filename -y -o$directory`)
     filename = joinpath(directory, basename(filename)[1:end-4])
     success(`$home/7z x $filename -y -ttar -o$directory`)

--- a/src/OpenDSSDirect.jl
+++ b/src/OpenDSSDirect.jl
@@ -110,6 +110,7 @@ include("ymatrix.jl")
 include("repl.jl")
 
 const dss = OpenDSSDirect.Text.Command
+const Examples = Utils.Examples
 
 function __init__()
 

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -3,11 +3,14 @@ dir = joinpath(@__DIR__, "../examples") |> abspath
 
 @testset "Examples" begin
 
-println("Timing 8760.jl")
-@time @test include(joinpath(dir, "8760.jl")) == nothing
-println("Timing custom_8760.jl")
-@time @test include(joinpath(dir, "custom_8760.jl")) == nothing
+    println("Timing 8760.jl")
+    @time @test include(joinpath(dir, "8760.jl")) == nothing
+    println("Timing custom_8760.jl")
+    @time @test include(joinpath(dir, "custom_8760.jl")) == nothing
 
-@test include(joinpath(dir, "timings.jl")) == nothing
+    @test include(joinpath(dir, "timings.jl")) == nothing
+
+    cd(joinpath(@__DIR__, "..") |> abspath)
+    @test download(OpenDSSDirect.Examples) |> abspath == joinpath(@__DIR__, "../examples/electricdss-tst-master") |> abspath
 
 end # testset


### PR DESCRIPTION
**Usage**:


```

julia> using OpenDSSDirect

julia> download(OpenDSSDirect.Examples);
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   135    0   135    0     0    369      0 --:--:-- --:--:-- --:--:--   368
100 12.7M  100 12.7M    0     0   911k      0  0:00:14  0:00:14 --:--:--  871k

shell> ls examples/electricdss-tst-master/Version7/Distrib/IEEETestCases/8500-Node/
Buscoords.dss                   Lines-Geometry.dss              Regulators.dss
CapControls.DSS                 Lines.dss                       Run_8500Node.dss
Capacitors.dss                  LoadXfmrCodes.dss               Run_8500Node_Unbal.dss
CloudTransient.dss              LoadXfmrs.dss                   Run_RecloserSiting.DSS
Feeder_Loads.dss                Loads.dss                       TplxFaultrate.dss
Fuses.DSS                       Master-unbal.dss                Transformers.dss
Generators.dss                  Master.dss                      Triplex_Linecodes.dss
LineCodes.dss                   Normalized-1s-2900-pts.CSV      Triplex_Lines.DSS
LineCodes2.DSS                  P174_Run_360kW_PV.DSS           UnbalancedLoads.DSS
LineGeometry.dss                P174_Run_Voltage_Profile.DSS    WireData.dss

help?> download(OpenDSSDirect.Examples)

  download(#temp#::Type{OpenDSSDirect.Utils.Examples}) -> String
  download(#temp#::Type{OpenDSSDirect.Utils.Examples}, folder::AbstractString) -> String


  Download examples into a "electricdss-tst-master" folder in given argument path. Defaults to the
  "examples" folder in the OpenDSSDirect package.

  Returns the downloaded folder name.
```
