### PR TITLE
Update download examples function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -168,13 +168,21 @@ Defaults to the "examples" folder in the OpenDSSDirect package.
 
 Returns the downloaded folder name.
 """
-function Base.download(::Type{Examples}, folder::AbstractString=joinpath(@__DIR__, "../examples") |> abspath)
-    url = "https://github.com/dss-extensions/electricdss-tst/archive/master.tar.gz"
-    tempfilename = Base.download(url)
+function Base.download(::Type{Examples}, folder::AbstractString=joinpath(@__DIR__, "../examples") |> abspath; force::Bool=false)
     directory = folder |> normpath |> abspath
-    mkpath(directory)
-    unzip(os, tempfilename, directory)
-    filename = joinpath(directory, "electricdss-tst-master")
+    electricdss_tst_master_folder = joinpath(directory, "electricdss-tst-master")
+    if force || !isdir(electricdss_tst_master_folder)
+        url = "https://github.com/dss-extensions/electricdss-tst/archive/master.tar.gz"
+        tempfilename = Base.download(url)
+        mkpath(directory)
+        rm(electricdss_tst_master_folder, recursive=true, force=true)
+        unzip(os, tempfilename, directory)
+        filename = electricdss_tst_master_folder
+    else
+        filename = electricdss_tst_master_folder
+        @warn "$filename already exists. Use `force=true` if you want to redownload the data."
+    end
+    return filename
 end
 
 function unzip(::Type{<:BSD}, filename, directory)


### PR DESCRIPTION

**Usage**

```

julia> using OpenDSSDirect

julia> download(OpenDSSDirect.Examples)
┌ Warning: /Users/$USER/GitRepos/OpenDSSDirect.jl/examples/electricdss-tst-master already exists. Use `force=true` if you want to redownload the data.
└ @ OpenDSSDirect.Utils ~/GitRepos/OpenDSSDirect.jl/src/utils.jl:183
"/Users/$USER/GitRepos/OpenDSSDirect.jl/examples/electricdss-tst-master"

julia> download(OpenDSSDirect.Examples, force=true)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   138    0   138    0     0    203      0 --:--:-- --:--:-- --:--:--   203
100 12.2M    0 12.2M    0     0  3105k      0 --:--:--  0:00:04 --:--:-- 4472k
"/Users/$USER/GitRepos/OpenDSSDirect.jl/examples/electricdss-tst-master"

help?> download
search: download

  download(url::AbstractString, [localfile::AbstractString])


  Download a file from the given url, optionally renaming it to the given local file name. If no filename is
  given this will download into a randomly-named file in your temp directory. Note that this function relies on
  the availability of external tools such as curl, wget or fetch to download the file and is provided for
  convenience. For production use or situations in which more options are needed, please use a package that
  provides the desired functionality instead.

  Returns the filename of the downloaded file.

  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────

  download(#temp#::Type{OpenDSSDirect.Utils.Examples}) -> String
  download(#temp#::Type{OpenDSSDirect.Utils.Examples}, folder::AbstractString; force) -> String



  Download examples into a "electricdss-tst-master" folder in given argument path. Defaults to the "examples"
  folder in the OpenDSSDirect package.

  Returns the downloaded folder name.

julia>

```