### PR TITLE
Change Vector{Float64} to Matrix{Float64}

### DIFF
--- a/src/linecodes.jl
+++ b/src/linecodes.jl
@@ -39,7 +39,7 @@ module LineCodes
     function Cmatrix()::Matrix{Float64}
         n = Phases()
         if n == 0
-            cmatrix = reshape([], (n, n))
+            cmatrix = reshape(Float64[], (0, 0))
         else
             cmatrix = reshape(Utils.get_float64_array(Lib.LineCodes_Get_Cmatrix), (n, n))
         end
@@ -49,7 +49,7 @@ module LineCodes
     """Capacitance matrix, nF per unit length (Setter)"""
     function Cmatrix(Value::Matrix{Float64})
         n = Phases()
-        Cmatrix(reshape(Value, (n * n, 1))[:])
+        Cmatrix(Value[:])
     end
 
     """Capacitance matrix, nF per unit length (Setter)"""
@@ -140,7 +140,7 @@ module LineCodes
     function Rmatrix()::Matrix{Float64}
         n = Phases()
         if n == 0
-            rmatrix = reshape([], (n, n))
+            rmatrix = reshape(Float64[], (0, 0))
         else
             rmatrix = reshape(Utils.get_float64_array(Lib.LineCodes_Get_Rmatrix), (n, n))
         end
@@ -150,7 +150,7 @@ module LineCodes
     """Resistance matrix, ohms per unit length (Setter)"""
     function Rmatrix(Value::Matrix{Float64})
         n = Phases()
-        Rmatrix(reshape(Value, (n * n, 1))[:])
+        Rmatrix(Value[:])
     end
 
     """Resistance matrix, ohms per unit length (Setter)"""
@@ -194,7 +194,7 @@ module LineCodes
     function Xmatrix()::Matrix{Float64}
         n = Phases()
         if n == 0
-            xmatrix = reshape([], (n, n))
+            xmatrix = reshape(Float64[], (0, 0))
         else
             xmatrix = reshape(Utils.get_float64_array(Lib.LineCodes_Get_Xmatrix), (n, n))
         end
@@ -204,7 +204,7 @@ module LineCodes
     """Reactance matrix, ohms per unit length (Setter)"""
     function Xmatrix(Value::Matrix{Float64})
         n = Phases()
-        Xmatrix(reshape(Value, (n * n, 1))[:])
+        Xmatrix(Value[:])
     end
 
     """Reactance matrix, ohms per unit length (Setter)"""

--- a/src/linecodes.jl
+++ b/src/linecodes.jl
@@ -36,8 +36,20 @@ module LineCodes
     end
 
     """Capacitance matrix, nF per unit length (Getter)"""
-    function Cmatrix()::Vector{Float64}
-        return Utils.get_float64_array(Lib.LineCodes_Get_Cmatrix)
+    function Cmatrix()::Matrix{Float64}
+        n = Phases()
+        if n == 0
+            cmatrix = reshape([], (n, n))
+        else
+            cmatrix = reshape(Utils.get_float64_array(Lib.LineCodes_Get_Cmatrix), (n, n))
+        end
+        return cmatrix
+    end
+
+    """Capacitance matrix, nF per unit length (Setter)"""
+    function Cmatrix(Value::Matrix{Float64})
+        n = Phases()
+        Cmatrix(reshape(Value, (n * n, 1))[:])
     end
 
     """Capacitance matrix, nF per unit length (Setter)"""
@@ -125,8 +137,20 @@ module LineCodes
     end
 
     """Resistance matrix, ohms per unit length (Getter)"""
-    function Rmatrix()::Vector{Float64}
-        return Utils.get_float64_array(Lib.LineCodes_Get_Rmatrix)
+    function Rmatrix()::Matrix{Float64}
+        n = Phases()
+        if n == 0
+            rmatrix = reshape([], (n, n))
+        else
+            rmatrix = reshape(Utils.get_float64_array(Lib.LineCodes_Get_Rmatrix), (n, n))
+        end
+        return rmatrix
+    end
+
+    """Resistance matrix, ohms per unit length (Setter)"""
+    function Rmatrix(Value::Matrix{Float64})
+        n = Phases()
+        Rmatrix(reshape(Value, (n * n, 1))[:])
     end
 
     """Resistance matrix, ohms per unit length (Setter)"""
@@ -167,8 +191,20 @@ module LineCodes
     end
 
     """Reactance matrix, ohms per unit length (Getter)"""
-    function Xmatrix()::Vector{Float64}
-        return Utils.get_float64_array(Lib.LineCodes_Get_Xmatrix)
+    function Xmatrix()::Matrix{Float64}
+        n = Phases()
+        if n == 0
+            xmatrix = reshape([], (n, n))
+        else
+            xmatrix = reshape(Utils.get_float64_array(Lib.LineCodes_Get_Xmatrix), (n, n))
+        end
+        return xmatrix
+    end
+
+    """Reactance matrix, ohms per unit length (Setter)"""
+    function Xmatrix(Value::Matrix{Float64})
+        n = Phases()
+        Xmatrix(reshape(Value, (n * n, 1))[:])
     end
 
     """Reactance matrix, ohms per unit length (Setter)"""

--- a/src/linecodes.jl
+++ b/src/linecodes.jl
@@ -213,5 +213,19 @@ module LineCodes
         Lib.LineCodes_Set_Xmatrix(ValuePtr, ValueCount)
     end
 
+    """Reactance matrix, ohms per unit length (Getter)"""
+    function Zmatrix()::Matrix{ComplexF64}
+        zmatrix = Rmatrix() + im * Xmatrix()
+        return zmatrix
+    end
+
+    """Reactance matrix, ohms per unit length (Setter)"""
+    function Zmatrix(Value::Matrix{ComplexF64})
+        r = real(Value)
+        i = imag(Value)
+        Rmatrix(r)
+        Xmatrix(i)
+    end
+
 end
 

--- a/src/lines.jl
+++ b/src/lines.jl
@@ -332,5 +332,19 @@ module Lines
         Lib.Lines_Set_Yprim(ValuePtr, ValueCount)
     end
 
+    """Impedance matrix, ohms per unit length. Matrix of doubles. (Getter)"""
+    function ZMatrix()::Matrix{ComplexF64}
+        zmatrix = RMatrix() + im * XMatrix()
+        return zmatrix
+    end
+
+    """Impedance matrix, ohms per unit length. Matrix of doubles. (Setter)"""
+    function ZMatrix(Value::Matrix{ComplexF64})
+        r = real(Value)
+        i = imag(Value)
+        RMatrix(r)
+        XMatrix(i)
+    end
+
 end
 

--- a/src/lines.jl
+++ b/src/lines.jl
@@ -64,7 +64,7 @@ module Lines
     function CMatrix()::Matrix{Float64}
         n = Phases()
         if n == 0
-            cmatrix = reshape([], (n, n))
+            cmatrix = reshape(Float64[], (0, 0))
         else
             cmatrix = reshape(Utils.get_float64_array(Lib.Lines_Get_Cmatrix), (n, n))
         end
@@ -74,7 +74,7 @@ module Lines
     """Capacitance matrix, nF per unit length (Setter)"""
     function CMatrix(Value::Matrix{Float64})
         n = Phases()
-        CMatrix(reshape(Value, (n * n, 1))[:])
+        CMatrix(Value[:])
     end
 
     """Capacitance matrix, nF per unit length (Setter)"""
@@ -222,7 +222,7 @@ module Lines
     function RMatrix()::Matrix{Float64}
         n = Phases()
         if n == 0
-            rmatrix = reshape([], (n, n))
+            rmatrix = reshape(Float64[], (0, 0))
         else
             rmatrix = reshape(Utils.get_float64_array(Lib.Lines_Get_Rmatrix), (n, n))
         end
@@ -232,7 +232,7 @@ module Lines
     """Resistance matrix (full), ohms per unit length. Matrix of doubles. (Setter)"""
     function RMatrix(Value::Matrix{Float64})
         n = Phases()
-        RMatrix(reshape(Value, (n * n, 1))[:])
+        RMatrix(Value[:])
     end
 
     """Resistance matrix (full), ohms per unit length. Vector of doubles. (Setter)"""
@@ -301,7 +301,7 @@ module Lines
     function XMatrix()::Matrix{Float64}
         n = Phases()
         if n == 0
-            xmatrix = reshape([], (n, n))
+            xmatrix = reshape(Float64[], (0, 0))
         else
             xmatrix = reshape(Utils.get_float64_array(Lib.Lines_Get_Xmatrix), (n, n))
         end
@@ -311,7 +311,7 @@ module Lines
     """Susceptance matrix, ohms per unit length. Matrix of doubles. (Setter)"""
     function XMatrix(Value::Matrix{Float64})
         n = Phases()
-        XMatrix(reshape(Value, (n * n, 1))[:])
+        XMatrix(Value[:])
     end
 
     """Susceptance matrix, ohms per unit length. Vector of doubles. (Setter)"""

--- a/src/lines.jl
+++ b/src/lines.jl
@@ -61,14 +61,24 @@ module Lines
     end
 
     """Capacitance matrix, nF per unit length (Getter)"""
-    function CMatrix()::Vector{Float64}
-        # TODO: should this method return Matrix{ComplexF64} with just imaginary components?
-        return Utils.get_float64_array(Lib.Lines_Get_Cmatrix)
+    function CMatrix()::Matrix{Float64}
+        n = Phases()
+        if n == 0
+            cmatrix = reshape([], (n, n))
+        else
+            cmatrix = reshape(Utils.get_float64_array(Lib.Lines_Get_Cmatrix), (n, n))
+        end
+        return cmatrix
+    end
+
+    """Capacitance matrix, nF per unit length (Setter)"""
+    function CMatrix(Value::Matrix{Float64})
+        n = Phases()
+        CMatrix(reshape(Value, (n * n, 1))[:])
     end
 
     """Capacitance matrix, nF per unit length (Setter)"""
     function CMatrix(Value::Vector{Float64})
-        # TODO: should this method accept Matrix{ComplexF64} with just imaginary components?
         Value, ValuePtr, ValueCount = Utils.prepare_float64_array(Value)
         Lib.Lines_Set_Cmatrix(ValuePtr, ValueCount)
     end
@@ -208,15 +218,25 @@ module Lines
         Lib.Lines_Set_Rho(Value)
     end
 
-    """Resistance matrix (full), ohms per unit length. Array of doubles. (Getter)"""
-    function RMatrix()::Vector{Float64}
-        # TODO: should this method return Matrix{ComplexF64} with just real components?
-        return Utils.get_float64_array(Lib.Lines_Get_Rmatrix)
+    """Resistance matrix (full), ohms per unit length. Matrix of doubles. (Getter)"""
+    function RMatrix()::Matrix{Float64}
+        n = Phases()
+        if n == 0
+            rmatrix = reshape([], (n, n))
+        else
+            rmatrix = reshape(Utils.get_float64_array(Lib.Lines_Get_Rmatrix), (n, n))
+        end
+        return rmatrix
     end
 
-    """Resistance matrix (full), ohms per unit length. Array of doubles. (Setter)"""
+    """Resistance matrix (full), ohms per unit length. Matrix of doubles. (Setter)"""
+    function RMatrix(Value::Matrix{Float64})
+        n = Phases()
+        RMatrix(reshape(Value, (n * n, 1))[:])
+    end
+
+    """Resistance matrix (full), ohms per unit length. Vector of doubles. (Setter)"""
     function RMatrix(Value::Vector{Float64})
-        # TODO: should this method accept Matrix{ComplexF64} with just real components?
         Value, ValuePtr, ValueCount = Utils.prepare_float64_array(Value)
         Lib.Lines_Set_Rmatrix(ValuePtr, ValueCount)
     end
@@ -277,15 +297,25 @@ module Lines
         Lib.Lines_Set_Xg(Value)
     end
 
-    """Susceptance matrix, ohms per unit length. Array of doubles. (Getter)"""
-    function XMatrix()::Vector{Float64}
-        # TODO: should this method return Matrix{ComplexF64} with just imaginary components?
-        return Utils.get_float64_array(Lib.Lines_Get_Xmatrix)
+    """Susceptance matrix, ohms per unit length. Matrix of doubles. (Getter)"""
+    function XMatrix()::Matrix{Float64}
+        n = Phases()
+        if n == 0
+            xmatrix = reshape([], (n, n))
+        else
+            xmatrix = reshape(Utils.get_float64_array(Lib.Lines_Get_Xmatrix), (n, n))
+        end
+        return xmatrix
     end
 
-    """Susceptance matrix, ohms per unit length. Array of doubles. (Setter)"""
+    """Susceptance matrix, ohms per unit length. Matrix of doubles. (Setter)"""
+    function XMatrix(Value::Matrix{Float64})
+        n = Phases()
+        XMatrix(reshape(Value, (n * n, 1))[:])
+    end
+
+    """Susceptance matrix, ohms per unit length. Vector of doubles. (Setter)"""
     function XMatrix(Value::Vector{Float64})
-        # TODO: should this method return Matrix{ComplexF64} with just imaginary components?
         Value, ValuePtr, ValueCount = Utils.prepare_float64_array(Value)
         Lib.Lines_Set_Xmatrix(ValuePtr, ValueCount)
     end

--- a/test/linecodes.jl
+++ b/test/linecodes.jl
@@ -34,11 +34,11 @@ init8500()
 @test LineCodes.Name() == "1ph-xx4_acsr4_acsr"
 @test LineCodes.Name(LineCodes.Name()) == nothing
 @test LineCodes.AllNames()[end] == "4/0triplex"
-@test LineCodes.Rmatrix() ≋ [0.40995115, 0.11809509, 0.11809509, 0.40995115] # TODO: change Rmatrix to RMatrix to be consistent with Lines
+@test LineCodes.Rmatrix() ≋ [0.40995115 0.11809509; 0.11809509 0.40995115] # TODO: change Rmatrix to RMatrix to be consistent with Lines
 @test LineCodes.Rmatrix(LineCodes.Rmatrix()) == nothing # TODO: change Rmatrix to RMatrix to be consistent with Lines
-@test LineCodes.Xmatrix() ≋ [0.16681819, 0.1275925, 0.1275925, 0.16681819] # TODO: change Xmatrix to XMatrix to be consistent with Lines
+@test LineCodes.Xmatrix() ≋ [0.16681819 0.1275925; 0.1275925 0.16681819] # TODO: change Xmatrix to XMatrix to be consistent with Lines
 @test LineCodes.Xmatrix(LineCodes.Xmatrix()) == nothing # TODO: change Xmatrix to XMatrix to be consistent with Lines
-@test LineCodes.Cmatrix() ≋ [3, -2.4, -2.4, 3.0] # TODO: change Cmatrix to CMatrix to be consistent with Lines
+@test LineCodes.Cmatrix() ≋ [3 -2.4; -2.4 3.0] # TODO: change Cmatrix to CMatrix to be consistent with Lines
 @test LineCodes.Cmatrix(LineCodes.Cmatrix()) == nothing # TODO: change Cmatrix to CMatrix to be consistent with Lines
 
 arr = String[]

--- a/test/linecodes.jl
+++ b/test/linecodes.jl
@@ -40,6 +40,9 @@ init8500()
 @test LineCodes.Xmatrix(LineCodes.Xmatrix()) == nothing # TODO: change Xmatrix to XMatrix to be consistent with Lines
 @test LineCodes.Cmatrix() ≋ [3 -2.4; -2.4 3.0] # TODO: change Cmatrix to CMatrix to be consistent with Lines
 @test LineCodes.Cmatrix(LineCodes.Cmatrix()) == nothing # TODO: change Cmatrix to CMatrix to be consistent with Lines
+@test isapprox(LineCodes.Zmatrix(), [0.409951+0.166818im  0.118095+0.127592im;
+                              0.118095+0.127592im  0.409951+0.166818im], rtol=0.00001)
+@test LineCodes.Zmatrix(LineCodes.Zmatrix()) == nothing
 
 arr = String[]
 for i in OpenDSSDirect.EachMember(LineCodes); push!(arr, LineCodes.Name()); end

--- a/test/lines.jl
+++ b/test/lines.jl
@@ -66,6 +66,9 @@ init8500()
                       -14.151460302936526 + 7.897357517772179im 14.151460302936526 - 7.897357479424346im]
 @test Lines.Yprim(Lines.Yprim()) == nothing
 
+@test Lines.ZMatrix() ≋ reshape([1.67466 + 0.93456im], (1, 1))
+@test Lines.ZMatrix(Lines.ZMatrix()) == nothing
+
 arr = String[]
 for i in OpenDSSDirect.EachMember(Lines); push!(arr, Lines.Name()); end
 for (i, n) in enumerate(OpenDSSDirect.EachMember(Lines, Lines.Name))

--- a/test/lines.jl
+++ b/test/lines.jl
@@ -4,6 +4,10 @@ init8500()
 
 @testset "Lines" begin
 
+@test Lines.RMatrix() == reshape([], (0, 0))
+@test Lines.CMatrix() == reshape([], (0, 0))
+@test Lines.XMatrix() == reshape([], (0, 0))
+
 @test Lines.First() == 1
 @test Lines.Next() == 2
 @test Lines.Phases() == 1
@@ -52,11 +56,11 @@ init8500()
 @test Lines.Spacing() == ""
 @test Lines.Spacing(Lines.Spacing()) == nothing
 @test Lines.AllNames()[end] == "tpx2224500658a0"
-@test Lines.RMatrix() ≋ [1.67466]
+@test Lines.RMatrix() ≋ reshape([1.67466], (1, 1))
 @test Lines.RMatrix(Lines.RMatrix()) == nothing
-@test Lines.XMatrix() ≋ [0.93456]
+@test Lines.XMatrix() ≋ reshape([0.93456], (1, 1))
 @test Lines.XMatrix(Lines.XMatrix()) == nothing
-@test Lines.CMatrix() ≋ [6.322849999999999]
+@test Lines.CMatrix() ≋ reshape([6.322849999999999], (1, 1))
 @test Lines.CMatrix(Lines.CMatrix()) == nothing
 @test Lines.Yprim() ≋ [14.151460302936526 - 7.897357479424346im -14.151460302936526 + 7.897357517772179im
                       -14.151460302936526 + 7.897357517772179im 14.151460302936526 - 7.897357479424346im]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 using Test
 
+include("init.jl")
+
 include("lowlevel.jl")
 include("basics.jl")
-
-include("init.jl")
 
 include("activeclass.jl")
 include("bus.jl")


### PR DESCRIPTION
Resolves #43 

**Usage**

```
$ julia-1.1 --check-bounds=yes --depwarn=no --color=yes --project
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.1.0 (2019-01-21)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using OpenDSSDirect

julia> path_to_examples = download(OpenDSSDirect.Examples)
┌ Warning: /Users/$USER/GitRepos/OpenDSSDirect.jl/examples/electricdss-tst-master already exists. Use `force=true` if you want to redownload the data.
└ @ OpenDSSDirect.Utils ~/GitRepos/OpenDSSDirect.jl/src/utils.jl:183
"/Users/$USER/GitRepos/OpenDSSDirect.jl/examples/electricdss-tst-master"

julia> dss("set editor=\"/bin/true\"")
""

julia> dss("redirect $path_to_examples/Distrib/IEEETestCases/8500-Node/Run_8500Node.dss")
""

julia> LineCodes.AllNames()[end]
"4/0triplex"

julia> LineCodes.Name()
"4/0triplex"

julia> LineCodes.Rmatrix()
2×2 Array{Float64,2}:
 0.409951  0.118095
 0.118095  0.409951

julia> Lines.RMatrix()
0×0 Array{Float64,2}

julia>

help?> Lines.RMatrix
  RMatrix() -> Array{Float64,2}



  Resistance matrix (full), ohms per unit length. Matrix of doubles. (Getter)

  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────

  RMatrix(Value::Array{Float64,2})



  Resistance matrix (full), ohms per unit length. Matrix of doubles. (Setter)

  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────

  RMatrix(Value::Array{Float64,1})



  Resistance matrix (full), ohms per unit length. Vector of doubles. (Setter)

julia>

```