### PR TITLE
Fix CktElement.YPrim function

### DIFF
--- a/src/ckt_element.jl
+++ b/src/ckt_element.jl
@@ -257,7 +257,7 @@ module CktElement
     function YPrim()::Array{ComplexF64, 2}
         r = Utils.get_complex64_array(Lib.CktElement_Get_Yprim)
         # TODO: should we transpose here?
-        return reshape(r, (Int(length(r)/2), Int(length(r)/2)))
+        return reshape(r, (Int(sqrt(length(r))), Int(sqrt(length(r)))))
     end
 
 end


### PR DESCRIPTION
`YPrim` is a symmetrical square Matrix. We need to take the `sqrt` of length to get the size of the matrix during the reshape operation. The previous tests divided by `2` instead. This worked when the length of the `ComplexF64` array was `4`. This PR fixes this issue.