### PR TITLE
Upgrade to the DSS C-API 0.10.3

### DIFF
--- a/test/cktelement.jl
+++ b/test/cktelement.jl
@@ -12,7 +12,7 @@ Lines.Next()
 @test CktElement.Open(0, 0) == nothing
 @test CktElement.Close(0, 0) == nothing
 @test CktElement.IsOpen(0, 0) == false
-@test CktElement.NumProperties() == 35
+@test CktElement.NumProperties() == 37
 @test CktElement.HasSwitchControl() == false
 @test CktElement.HasVoltControl() == false
 @test CktElement.NumControls() == 0

--- a/test/executive.jl
+++ b/test/executive.jl
@@ -4,8 +4,8 @@ init8500()
 
 @testset "Executive" begin
 
-@test Executive.NumCommands() == 107
-@test Executive.NumOptions() == 111
+@test Executive.NumCommands() == 111
+@test Executive.NumOptions() == 115
 @test Executive.Command(2) == "Edit"
 @test Executive.Option(2) == "element"
 @test Executive.CommandHelp(2)[1:7] == "Edit an"

--- a/test/loadshape.jl
+++ b/test/loadshape.jl
@@ -29,7 +29,7 @@ OpenDSSDirect.Text.Command("""
 @test LoadShape.Name() == "residential"
 @test LoadShape.Name(LoadShape.Name()) == nothing
 @test LoadShape.AllNames() == ["default","residential","commercial_sm","commercial_md"]
-@test LoadShape.PMult()[end] ≋ 0.366545
+@test LoadShape.PMult()[end] ≋ 0.539266
 @test LoadShape.PMult(LoadShape.PMult()) == nothing
 @test LoadShape.QMult() ≋ [0.0]
 @test LoadShape.QMult(LoadShape.QMult()) == nothing


### PR DESCRIPTION
The new version has some important fixes, more validation, new functions and enhanced performance.

The Windows DLLs for our custom KLUSolve now use GCC.

Opening a PR to trigger all tests, might need a few more changes. I also need to fix the line-ending on my local repo.