### PR TITLE
DSS C-API 0.10.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenDSSDirect"
 uuid = "a8b11937-1041-50f2-9818-136bb7a8fb06"
 authors = ["Tom Short <tshort.rlists@gmail.com>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ abstract type Windows <: AbstractOS end
 abstract type MacOS <: BSD end
 abstract type Linux <: BSD end
 
-const DSS_CAPI_TAG = "0.10.6"
+const DSS_CAPI_TAG = "0.10.7"
 
 function download(::Type{MacOS})
 

--- a/src/bus.jl
+++ b/src/bus.jl
@@ -190,4 +190,14 @@ function LoadList()::Vector{String}
     return get_string_array(Lib.Bus_Get_LoadList)
 end
 
+"""Array with the names of all PCE connected to the active bus"""
+function AllPCEatBus()::Vector{String}
+    return get_string_array(Lib.Bus_Get_AllPCEatBus)
+end
+
+"""Array with the names of all PDE connected to the active bus"""
+function AllPDEatBus()::Vector{String}
+    return get_string_array(Lib.Bus_Get_AllPDEatBus)
+end
+
 end

--- a/src/ckt_element.jl
+++ b/src/ckt_element.jl
@@ -242,6 +242,11 @@ function SeqVoltages()::Vector{Float64}
     return get_float64_array(Lib.CktElement_Get_SeqVoltages)
 end
 
+"""Returns the total powers (complex) at ALL terminals of the active circuit element."""
+function TotalPowers()::Vector{ComplexF64}
+    return get_complex64_array(Lib.CktElement_Get_TotalPowers)
+end
+
 """Complex array of voltages at terminals"""
 function Voltages()::Vector{ComplexF64}
     return get_complex64_array(Lib.CktElement_Get_Voltages)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,7 +1,7 @@
 # Automatically generated using Clang.jl
 
 
-const DSS_CAPI_V7_VERSION = "0.10.6"
+const DSS_CAPI_V7_VERSION = "0.10.7"
 
 @cenum MonitorModes::UInt32 begin
     MonitorModes_VI = 0

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -102,6 +102,14 @@ function ActiveClass_Get_ActiveClassParent()
     ccall((:ActiveClass_Get_ActiveClassParent, LIBRARY), Cstring, ())
 end
 
+function Bus_Get_AllPCEatBus(ResultPtr, ResultCount)
+    ccall((:Bus_Get_AllPCEatBus, LIBRARY), Cvoid, (Ptr{Ptr{Cstring}}, Ptr{Int32}), ResultPtr, ResultCount)
+end
+
+function Bus_Get_AllPDEatBus(ResultPtr, ResultCount)
+    ccall((:Bus_Get_AllPDEatBus, LIBRARY), Cvoid, (Ptr{Ptr{Cstring}}, Ptr{Int32}), ResultPtr, ResultCount)
+end
+
 function Bus_Get_Name()
     ccall((:Bus_Get_Name, LIBRARY), Cstring, ())
 end
@@ -1092,6 +1100,14 @@ end
 
 function CktElement_Get_IsIsolated()
     ccall((:CktElement_Get_IsIsolated, LIBRARY), UInt16, ())
+end
+
+function CktElement_Get_TotalPowers(ResultPtr, ResultCount)
+    ccall((:CktElement_Get_TotalPowers, LIBRARY), Cvoid, (Ptr{Ptr{Cdouble}}, Ptr{Int32}), ResultPtr, ResultCount)
+end
+
+function CktElement_Get_TotalPowers_GR()
+    ccall((:CktElement_Get_TotalPowers_GR, LIBRARY), Cvoid, ())
 end
 
 function CmathLib_Get_cmplx(ResultPtr, ResultCount, RealPart, ImagPart)
@@ -2876,6 +2892,10 @@ end
 
 function Meters_Get_SectTotalCust()
     ccall((:Meters_Get_SectTotalCust, LIBRARY), Int32, ())
+end
+
+function Meters_Get_ZonePCE(ResultPtr, ResultCount)
+    ccall((:Meters_Get_ZonePCE, LIBRARY), Cvoid, (Ptr{Ptr{Cstring}}, Ptr{Int32}), ResultPtr, ResultCount)
 end
 
 function Monitors_Get_AllNames(ResultPtr, ResultCount)

--- a/src/meters.jl
+++ b/src/meters.jl
@@ -276,4 +276,9 @@ function Totals()::Vector{Float64}
     return get_float64_array(Lib.Meters_Get_Totals)
 end
 
+"""Returns the list of all PCE within the area covered by the energy meter"""
+function ZonePCE()::Vector{String}
+    return get_string_array(Lib.Meters_Get_ZonePCE)
+end
+
 end

--- a/test/bus.jl
+++ b/test/bus.jl
@@ -40,5 +40,10 @@ Circuit.SetActiveBus("M1047751")
 @test Bus.puVLL() ≋ [-99999.0 + 0.0im]
 @test Bus.VMagAngle() ≋ [12.148177279538402, 41.934023780152195]''
 @test Bus.puVmagAngle() ≋ [0.0016873504625111767, 41.934023780152195]''
+@test Bus.AllPDEatBus() == ["Line.ln5865236-1", "Line.ln5623397-1"]
+
+Circuit.SetActiveBus("SX2973158C")
+
+@test Bus.AllPCEatBus() == ["Load.138259c0"]
 
 end # testset

--- a/test/cktelement.jl
+++ b/test/cktelement.jl
@@ -12,7 +12,7 @@ Lines.Next()
 @test CktElement.Open(0, 0) == nothing
 @test CktElement.Close(0, 0) == nothing
 @test CktElement.IsOpen(0, 0) == false
-@test CktElement.NumProperties() == 37
+@test CktElement.NumProperties() == 38
 @test CktElement.HasSwitchControl() == false
 @test CktElement.HasVoltControl() == false
 @test CktElement.NumControls() == 0
@@ -57,5 +57,6 @@ Lines.Next()
                                      177.9319402443363 -2.0853832620851183]
 @test CktElement.VoltagesMagAng() ≋ [7691.655711894497 7691.542956049531
                                     -167.10323234086837 -167.10344473228216]
+@test CktElement.TotalPowers() ≋ [14.0052+3.74347im, -14.005-3.7479im]
 
 end # testset

--- a/test/executive.jl
+++ b/test/executive.jl
@@ -4,7 +4,7 @@ init8500()
 
 @testset "Executive" begin
 
-@test Executive.NumCommands() == 114
+@test Executive.NumCommands() == 118
 @test Executive.NumOptions() == 115
 @test Executive.Command(2) == "Edit"
 @test Executive.Option(2) == "element"

--- a/test/meters.jl
+++ b/test/meters.jl
@@ -90,5 +90,8 @@ end
 @test arr == Meters.AllNames()
 @test length(arr) == length(OpenDSSDirect.EachMember(Meters))
 
+@test Meters.ZonePCE() == []
+
+
 
 end # testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ include("init.jl")
 
 println(OpenDSSDirect.Basic.Version())
 
-@test ODD.Lib.DSS_CAPI_V7_VERSION == "0.10.6"
+@test ODD.Lib.DSS_CAPI_V7_VERSION == "0.10.7"
 
 include("lowlevel.jl")
 include("basics.jl")


### PR DESCRIPTION
Upgrade to DSS C-API 0.10.7:
- Project.toml: Increment version to 0.7.1
- New functions ported from the upstream OpenDSS: Bus.AllPCEatBus, Bus.AllPDEatBus, CktElement.TotalPowers, Meter.ZonePCE
- Tests updated to include the new functions and new DSS commands

Changes from DSS C-API Version 0.10.7:

- Simple maintenance release, which includes most changes up to OpenDSS v9.1.3.4 (revision 2963).
- Includes an important bug fix related to the `CapRadius` DSS property. If your DSS scripts included the pattern `GMRac=... rad=...` or `GMRac=... diam=...` (in this order and without specifying `CapRadius`), you should upgrade and re-evaluate the results. 
- This version should be fully API compatible with 0.10.3+.
- A reference document listing the DSS commands and properties for all DSS elements is now available at https://github.com/dss-extensions/dss_capi/blob/0.10.x/docs/dss_properties.md
- New functions API ported from the official OpenDSS include: `Bus_Get_AllPCEatBus`, `Bus_Get_AllPDEatBus`, `CktElement_Get_TotalPowers`, `Meters_Get_ZonePCE`.
- The changes ported from the official OpenDSS include the following (check the repository for more details):
    - "Adds LineType property to LineCode and LineGeometry objects."
    - "Correcting bug found in storage device when operating in idling mode. It was preventing the solution of other test feeders (IEEE 9500)"
    - "Enabling fuel option for generator, fixing bug found in TotalPower command."
    - "Adding kvar compensation calculation for normalizing reactive power at feeder head. v 9.1.2.4"
    - "Adding: - Line type variable to line definition. - AllPCEatBus and AllPDEatBus commands to the executive command set. - AllPCEatBus and AllPDEatBus commands to bus interface in COM/DLL. (...)"
    - "Adding capability to energy meter for getting the list of all PCE (shunt) within a zone. Interface "AllPCEatZone" for COM/DLL created."
    - "Fixing bug found when calculating voltage bases with large amount of numbers (large array)."
     
