### PR TITLE
Upgrade DSS C-API to 0.10.7-1

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ abstract type Windows <: AbstractOS end
 abstract type MacOS <: BSD end
 abstract type Linux <: BSD end
 
-const DSS_CAPI_TAG = "0.10.7"
+const DSS_CAPI_TAG = "0.10.7-1"
 
 function download(::Type{MacOS})
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,7 +1,7 @@
 # Automatically generated using Clang.jl
 
 
-const DSS_CAPI_V7_VERSION = "0.10.7"
+const DSS_CAPI_V7_VERSION = "0.10.7-1"
 
 @cenum MonitorModes::UInt32 begin
     MonitorModes_VI = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ include("init.jl")
 
 println(OpenDSSDirect.Basic.Version())
 
-@test ODD.Lib.DSS_CAPI_V7_VERSION == "0.10.7"
+@test ODD.Lib.DSS_CAPI_V7_VERSION == "0.10.7-1"
 
 include("lowlevel.jl")
 include("basics.jl")


### PR DESCRIPTION
Compared to DSS C-API 0.10.7, it's just a fix to an issue with some of the reports from energy meters.

Creating a PR to let the tests run and be sure everything is fine.