### PR TITLE
DSS C-API 0.13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - os: macOS-latest
             julia-arch: x86
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
@@ -33,7 +33,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenDSSDirect"
 uuid = "a8b11937-1041-50f2-9818-136bb7a8fb06"
 authors = ["Tom Short <tshort.rlists@gmail.com>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ abstract type Windows <: AbstractOS end
 abstract type MacOS <: BSD end
 abstract type Linux <: BSD end
 
-const DSS_CAPI_TAG = "0.13.1"
+const DSS_CAPI_TAG = "0.13.2"
 
 function download(::Type{MacOS})
     if Sys.ARCH == :aarch64

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -88,7 +88,10 @@ function download(::Type{Windows})
     if Base.VERSION < v"1.3.0"
         bin7z = "$home/7z"
     else
-        bin7z = "$(joinpath(home, "..", "libexec", "7z"))"
+        bin7z = "$(joinpath(home, "..", "libexec", "7z.exe"))"
+        if !isfile(bin7z)
+            bin7z = "$(joinpath(home, "..", "libexec", "julia", "7z.exe"))"
+        end
     end
 
     success(`$bin7z x $filename -y -o$directory`)
@@ -114,7 +117,10 @@ function download_messages(::Type{Windows})
     if Base.VERSION < v"1.3.0"
         bin7z = "$home/7z"
     else
-        bin7z = "$(joinpath(home, "..", "libexec", "7z"))"
+        bin7z = "$(joinpath(home, "..", "libexec", "7z.exe"))"
+        if !isfile(bin7z)
+            bin7z = "$(joinpath(home, "..", "libexec", "julia", "7z.exe"))"
+        end
     end
 
     success(`$bin7z x $filename -y -o$directory`)

--- a/src/common.jl
+++ b/src/common.jl
@@ -147,8 +147,8 @@ end
     DSSJSONFlags_FullNames = 8
     DSSJSONFlags_Pretty = 16
     DSSJSONFlags_ExcludeDisabled = 32
-    DSSJSONFlags_State = 64
-    DSSJSONFlags_Debug = 128
+    DSSJSONFlags_SkipDSSClass = 64
+    DSSJSONFlags_LowercaseKeys = 128
 end
 
 @cenum BatchOperation::UInt32 begin

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -7159,4 +7159,4 @@ function DSS_Get_CompatFlags()
     ccall((:DSS_Get_CompatFlags, LIBRARY), UInt32, ())
 end
 
-const DSS_CAPI_VERSION = "0.13.1"
+const DSS_CAPI_VERSION = "0.13.2"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -429,7 +429,10 @@ function unzip(::Type{Windows}, filename, directory)
     if Base.VERSION < v"1.3.0"
         bin7z = "$home/7z"
     else
-        bin7z = "$(joinpath(home, "..", "libexec", "7z"))"
+        bin7z = "$(joinpath(home, "..", "libexec", "7z.exe"))"
+        if !isfile(bin7z)
+            bin7z = "$(joinpath(home, "..", "libexec", "julia", "7z.exe"))"
+        end
     end
     @assert success(`$bin7z x $filename -y -o$directory`) "Unable to extract $filename to $directory"
 end


### PR DESCRIPTION
Minor changes:

- Increment version to 0.9.2
- DSS C-API 0.13.2, notable for ODD.jl:
    - Some more null-checks in Topology/EnergyMeter (if users try to use uninitialized data)
    - Fail earlier on invalid edits (avoids some rare segfaults, also due to uninitialized/unexpected pointers)
    - `Text_CommandBlock`: simplify by reusing DoRedirect, enabling block comments in the string
    - Adjust JSON exports, add some option flags. All classes should now have useful, correct output.
- Minor fixes for Julia 1.9 on Windows (the 7-zip executable was moved)
- Handle some deprecation warnings from GitHub Actions