### PR TITLE
DSS C-API 0.13.3 and doc updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,56 @@
+**Please also read the [DSS C-API engine changelog](https://github.com/dss-extensions/dss_capi/blob/master/docs/changelog.md) which tracks the engine changes.** Most of the engine changes do not affect the API code on the Julia level.**
+
+For a more complete list of changes, visit the [Git repository and Releases page on GitHub](https://github.com/dss-extensions/OpenDSSDirect.jl).
+
+### OpenDSSDirect v0.9.3 Release Notes
+
+- Update the engine to DSS C-API v0.13.3. This includes important bugfixes to UPFC, Capacitor, and Reactor components, as well as other small changes.
+- Update documentation.
+- Add new flag `DSSCompatFlags_SaveCalcVoltageBases`: this flag forces the `save circuit` to always include `CalcVoltageBases` in the saved files. 
+Use it with `Basic.DSSCompatFlags()`.
+
+### OpenDSSDirect v0.9.2 Release Notes
+
+- Update the engine to DSS C-API v0.13.2.
+- Address Julia 1.9 compatibility issues on Windows.
+- Add new flags `DSSJSONFlags_SkipDSSClass` and `DSSJSONFlags_LowercaseKeys` to control JSON output of the engine.
+
+### OpenDSSDirect v0.9.1 Release Notes
+
+- Update the engine to DSS C-API v0.13.1.
+
+### OpenDSSDirect v0.9.0 Release Notes
+
+- Update the engine to DSS C-API v0.13.0.
+- Enable creating multiple DSS engines. Each engine instance is thread-safe, so multiple Julia threads can be used. That is, using one thread per engine is safe.
+
+### OpenDSSDirect v0.8.1 Release Notes
+
+- Update the engine to DSS C-API v0.12.1.
+- Update modules with new functions and add several modules (CNData, GICSources, LineGeometries, LineSpacings, Parallel, Reactors, ReduceCkt, Storages, TSData, WireData, ZIP).
+
+### OpenDSSDirect v0.8.0 Release Notes
+
+- Update the engine to DSS C-API v0.12.0.
+
+### OpenDSSDirect v0.7.3 Release Notes
+
+- Add more `Idx` functions (several modules).
+- Use flags/enums in more functions.
+
+### OpenDSSDirect v0.7.2 Release Notes
+
+- Update the engine to DSS C-API v0.10.7-1, which includes a fix to an issue with energy meter reports.
+
+### OpenDSSDirect v0.7.1 Release Notes
+
+- Update the engine to DSS C-API v0.10.7.
+
+### OpenDSSDirect v0.7.0 Release Notes
+
+- Update the engine to DSS C-API v0.10.6.
+- Adjust several modules to add new functions.
+
 ### OpenDSSDirect v0.6.1 Release Notes
 
 - Translate OpenDSS Errors to Julia Exceptions

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenDSSDirect"
 uuid = "a8b11937-1041-50f2-9818-136bb7a8fb06"
 authors = ["Tom Short <tshort.rlists@gmail.com>"]
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 [![GitHub Actions: Tests](https://github.com/dss-extensions/OpenDSSDirect.jl/workflows/CI/badge.svg)](https://github.com/dss-extensions/OpenDSSDirect.jl/actions/workflows/ci.yml)
 
-OpenDSSDirect.jl is a cross-platform Julia package implements a "direct" library interface to [OpenDSS](http://smartgrid.epri.com/SimulationTool.aspx) using [DSS C-API](https://github.com/dss-extensions/dss_capi/).
+OpenDSSDirect.jl is a cross-platform Julia package implements a "direct" library interface to [OpenDSS](http://smartgrid.epri.com/SimulationTool.aspx) using [DSS C-API](https://github.com/dss-extensions/dss_capi/), an alternative implementation.
 
 OpenDSS is an open-source distribution system simulator.
 
-Originally, the package used the OpenDSSDirect library from the official OpenDSS repository. Since OpenDSS is officially Windows-only, this package was migrated to use DSS C-API in 2019. The DSS C-API library is a community implementation of the OpenDSS engine built with the Free Pascal compiler, targetting cross-platform compatibility and an extended API. See its repository [here](https://github.com/dss-extensions/dss_capi) for the full Pascal/Delphi code, or https://dss-extensions.org/ for an overview of the projects around it.
+Originally, the package used the OpenDSSDirect library from the official OpenDSS repository. Since OpenDSS is officially Windows-only, this package was migrated to use DSS C-API in 2019. The DSS C-API library is a community implementation of the OpenDSS engine built with the Free Pascal compiler, targeting cross-platform compatibility and an extended API. See its repository [here](https://github.com/dss-extensions/dss_capi) for the full Pascal/Delphi code, or https://dss-extensions.org/ for an overview of the projects around it.
 
-See also [OpenDSSDirect.py](https://github.com/dss-extensions/OpenDSSDirect.py) for a package in Python with similar calling style, or [DSS_Python](https://github.com/dss-extensions/dss_python) and [DSS_MATLAB](https://github.com/dss-extensions/dss_matlab) for packages that mimic the OpenDSS COM API organization and style.
+For a general FAQ and many other links, see https://github.com/dss-extensions/dss-extensions#readme
 
-**This package is now available for Windows, Mac, and Linux.**
+See also [OpenDSSDirect.py](https://github.com/dss-extensions/OpenDSSDirect.py) for a package in Python with similar calling style, or [DSS-Python](https://github.com/dss-extensions/dss_python), [DSS_MATLAB](https://github.com/dss-extensions/dss_matlab) and [dss_sharp](https://github.com/dss-extensions/dss_sharp) for packages that mimic the OpenDSS COM API organization and style.
+
+**This package is available for Windows, macOS (x86 and ARM processors), and Linux (x86 and ARM processors).**
 
 ### Documentation
 
@@ -18,9 +20,9 @@ See also [OpenDSSDirect.py](https://github.com/dss-extensions/OpenDSSDirect.py) 
 
 The documentation for the development version of this package is [here](https://dss-extensions.github.io/OpenDSSDirect.jl/latest/).
 
-We also recommend reading the [known differences](https://github.com/dss-extensions/dss_capi/blob/0.10.x/docs/known_differences.md) document from DSS C-API, which lists the notable behavior differences versus the official OpenDSS engine.
+We also recommend reading the [known differences](https://github.com/dss-extensions/dss_capi/blob/master/docs/known_differences.md) document from DSS C-API, which lists the notable behavior differences versus the official OpenDSS engine.
 
-An up-to-date reference of the properties on the level of the DSS language [is also available](https://github.com/dss-extensions/dss_capi/blob/0.10.x/docs/dss_properties.md).
+An up-to-date reference of the properties on the level of the DSS language [is also available](https://github.com/dss-extensions/dss_capi/blob/master/docs/dss_properties.md).
 
 ### Installation
 
@@ -34,11 +36,15 @@ julia> ]
 ### Troubleshooting
 
 This package interfaces with the OpenDSS engine using a library interface, so a good understanding of OpenDSS will help troubleshooting.
-There are plenty of useful resources located [here](https://sourceforge.net/p/electricdss/code/HEAD/tree/trunk/Version8/Doc/).
+There are plenty of useful resources located [here](https://sourceforge.net/p/electricdss/code/HEAD/tree/trunk/Version8/Doc/). If you
+have experience with the official OpenDSS COM implementation, the following document compares our two Python modules, DSS-Python 
+(same structure as the OpenDSS COM module) and OpenDSSDirect.py (similar structure to OpenDSSDirect.jl): 
+[DSS-Extensions — OpenDSS: Overview of Python APIs](https://dss-extensions.org/python_apis.html).
 
-If you are having issues using this Julia interface, feel free to open an Issue on GitHub [here](https://github.com/dss-extensions/OpenDSSDirect.jl/issues/new).
+If you are having issues using this Julia interface, feel free to open an Issue on GitHub [here](https://github.com/dss-extensions/OpenDSSDirect.jl/issues/new) or
+post at our [general Discussions page](https://github.com/orgs/dss-extensions/discussions/categories/general).
 
 ### Thanks
 
-Thanks to @tshort for the original package.
+Thanks to @tshort for the original package.  
 Thanks to @kdheepak, @PMeira and @GordStephen for their contributions.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ abstract type Windows <: AbstractOS end
 abstract type MacOS <: BSD end
 abstract type Linux <: BSD end
 
-const DSS_CAPI_TAG = "0.13.2"
+const DSS_CAPI_TAG = "0.13.3"
 
 function download(::Type{MacOS})
     if Sys.ARCH == :aarch64

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -118,6 +118,9 @@ search: Circuit
 
 Here is a list of modules supported by this API. Each module has several functions.
 
+Functions or modules that are not present in the official OpenDSS implementation 
+are marked "(API Extension)".
+
 ## `dss`
 
 ```@docs

--- a/docs/src/dssmode.md
+++ b/docs/src/dssmode.md
@@ -1,6 +1,8 @@
 
 # DSS REPL Mode
 
+**NOTE:** this currently [does not support Linux](https://github.com/dss-extensions/OpenDSSDirect.jl/issues/72). Contributions are welcome!
+
 OpenDSSDirect also includes a custom REPL mode for entering OpenDSS commands directly.
 This is similar to the Help (`?`) and Shell (`;`) modes.
 Use the right parenthesis (`)`) to enter DSS mode.

--- a/docs/src/flags.md
+++ b/docs/src/flags.md
@@ -26,4 +26,7 @@ Lib.LoadStatus
 Lib.Options
 Lib.MonitorModes
 Lib.SolveModes
+Lib.DSSJSONFlags
+Lib.SolverOptions
+Lib.DSSCompatFlags
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,11 +1,15 @@
 # OpenDSSDirect
 
 [OpenDSS](http://smartgrid.epri.com/SimulationTool.aspx) is an open-source
-distribution system simulator. This Julia package implements a "direct" library
-interface to OpenDSS. See [this
-documentation](http://svn.code.sf.net/p/electricdss/code/trunk/Distrib/Doc/OpenDSS_Direct_DLL.pdf)
-for detailed information on the direct library interface to OpenDSS. The direct
-library interface can be faster than the more traditional COM interface.
+distribution system simulator. This Julia package implements a native, "direct" library
+interface to OpenDSS. Since 2019, this project uses DSS C-API, an alternative API and OpenDSS engine
+implementation maintained by the community. See the [DSS C-API repository](https://github.com/dss-extensions/dss_capi/)
+for move information in general, as well as alternatives for other programming languages.
+
+The interface can be faster than the more traditional COM interface, and allows for multi-platform
+support. Currently we support Windows, Linux and macOS, on ARM and x86 processors.
+
+See also the [DSS-Extensions site](https://dss-extensions.org/) for more.
 
 ## Installation
 
@@ -23,13 +27,15 @@ To install the latest development version, use the following from within Julia:
 (v1.1) pkg> dev OpenDSSDirect
 ```
 
-This package includes OpenDSS as a library. You do not have to install OpenDSS
+This package includes our alternative OpenDSS as a library. You do not have to install OpenDSS
 separately. In particular, it includes the OpenDSSDirect dynamically linked
 library using [dss_capi](https://github.com/dss-extensions/dss_capi) that implements the direct-access API.
 
+Users new to OpenDSS are still encouraged to use EPRI's official documentation and examples in general.
+
 Note that this should work on 32- and 64-bit Windows systems and 64-bit Linux
-and Mac systems. The Windows, Mac and Linux libraries are taken from the
-[dss_capi releases](https://github.com/dss-extensions/dss_capi/releases) page.
+and Mac systems. The Windows, macOS and Linux libraries are taken from the
+[dss_capi releases](https://github.com/dss-extensions/dss_capi/releases) page, downloaded automatically.
 
 ## Features
 
@@ -44,7 +50,13 @@ Julia has several key features for advanced operations with OpenDSS:
   parallel. This includes parallel operations on multiple CPU cores and
   parallel operations on processes in a cluster. See
   [examples/8760_pmap.jl](https://github.com/dss-extensions/OpenDSSDirect.jl/blob/master/examples/8760_pmap.jl)
-  for an example of an annual simulation split among local CPU cores.
+  for an example of an annual simulation split among local CPU cores. The
+  parallel support also includes the context API from DSS-Extensions, which
+  allows using multiple DSS engines in the same process. See
+  [test/ctx_threads.jl](https://github.com/dss-extensions/OpenDSSDirect.jl/blob/master/test/ctx_threads.jl)
+  for a minimal example of how to use this feature. Note that this is not possible in the official OpenDSS engine.
+  For completeness, the `Parallel` API from the PM version of OpenDSS is also available, but using
+  Julia-native operations is recommended.
 
 * **Optimization** -- Julia has strong support for optimization.
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -169,4 +169,5 @@ end
     DSSCompatFlags_NoSolverFloatChecks = 1
     DSSCompatFlags_BadPrecision = 2
     DSSCompatFlags_InvControl9611 = 4
+    DSSCompatFlags_SaveCalcVoltageBases = 8
 end

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -7159,4 +7159,4 @@ function DSS_Get_CompatFlags()
     ccall((:DSS_Get_CompatFlags, LIBRARY), UInt32, ())
 end
 
-const DSS_CAPI_VERSION = "0.13.2"
+const DSS_CAPI_VERSION = "0.13.3"

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -275,7 +275,11 @@ function RdcOhms(dss::DSSContext, Value::Float64)
 end
 RdcOhms(Value::Float64) = RdcOhms(DSS_DEFAULT_CTX, Value)
 
-"""All winding currents in CSV string form like the WdgCurrents property"""
+"""All winding currents in CSV string form like the WdgCurrents property
+
+WARNING: If the transformer has open terminal(s), results may be wrong, i.e. avoid using this
+in those situations. For more information, see https://github.com/dss-extensions/dss-extensions/issues/24
+"""
 function strWdgCurrents(dss::DSSContext)::String
     return get_string(@checked Lib.Transformers_Get_strWdgCurrents(dss.ctx))
 end
@@ -287,13 +291,21 @@ function LossesByType(dss::DSSContext)::Array{ComplexF64}
 end
 LossesByType() = LossesByType(DSS_DEFAULT_CTX)
 
-"""All Winding currents (ph1, wdg1, wdg2,... ph2, wdg1, wdg2 ...)"""
+"""All Winding currents (ph1, wdg1, wdg2,... ph2, wdg1, wdg2 ...)
+
+WARNING: If the transformer has open terminal(s), results may be wrong, i.e. avoid using this
+in those situations. For more information, see https://github.com/dss-extensions/dss-extensions/issues/24
+"""
 function WdgCurrents(dss::DSSContext)::Array{Float64}
     return get_float64_array(Lib.Transformers_Get_WdgCurrents, dss.ctx)
 end
 WdgCurrents() = WdgCurrents(DSS_DEFAULT_CTX)
 
-"""Complex array of voltages for active winding"""
+"""Complex array of voltages for active winding
+
+WARNING: If the transformer has open terminal(s), results may be wrong, i.e. avoid using this
+in those situations. For more information, see https://github.com/dss-extensions/dss-extensions/issues/24
+"""
 function WdgVoltages(dss::DSSContext)::Array{ComplexF64}
     return get_complex64_array(Lib.Transformers_Get_WdgVoltages, dss.ctx)
 end


### PR DESCRIPTION
The update to DSS C-API v0.13.3 is mostly to include the fixes for delta Capacitors/Reactors, and losses in UPFC. These were present in OpenDSS (both implementations, official and ours) for several years.

I also updated some of the docs to mention some missing things and added a few more links.

If the tests pass as expected, I'll merge and tag a new release since there were few changes on the Julia code.