### PR TITLE
DSS C-API v0.14.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 For a more complete list of changes, visit the [Git repository and Releases page on GitHub](https://github.com/dss-extensions/OpenDSSDirect.jl).
 
+### OpenDSSDirect v0.9.8 Release Notes
+
+- Update the engine to DSS C-API v0.14.3. There are a few bugfixes, [please check the AltDSS/DSS C-API changelog](https://github.com/dss-extensions/dss_capi/blob/master/docs/changelog.md#version-0143-2024-03-13), notably functions CktElement.Open/Close/IsOpen have been fixed and now also check for valid terminals.
+
+
 ### OpenDSSDirect v0.9.7 Release Notes
 
 - Fix low-level signature for `Lib.Circuit_FromJSON`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenDSSDirect"
 uuid = "a8b11937-1041-50f2-9818-136bb7a8fb06"
 authors = ["Tom Short <tshort.rlists@gmail.com>"]
-version = "0.9.7"
+version = "0.9.8"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ abstract type Windows <: AbstractOS end
 abstract type MacOS <: BSD end
 abstract type Linux <: BSD end
 
-const DSS_CAPI_TAG = "0.14.1"
+const DSS_CAPI_TAG = "0.14.3"
 
 function download(::Type{MacOS})
     if Sys.ARCH == :aarch64

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -7175,4 +7175,4 @@ function Circuit_FromJSON(ctx::Ptr{Cvoid}, circ, options)
     ccall((:ctx_Circuit_FromJSON, LIBRARY), Cvoid, (Ptr{Cvoid}, Cstring, Int32,), ctx, circ, options)
 end
 
-const DSS_CAPI_VERSION = "0.14.1"
+const DSS_CAPI_VERSION = "0.14.3"

--- a/test/cktelement.jl
+++ b/test/cktelement.jl
@@ -9,9 +9,12 @@ Lines.Next()
 @test CktElement.NumTerminals() == 2
 @test CktElement.NumConductors() == 1
 @test CktElement.NumPhases() == 1
-@test CktElement.Open(0, 0) === nothing
-@test CktElement.Close(0, 0) === nothing
-@test CktElement.IsOpen(0, 0) == false
+@test_throws OpenDSSDirect.OpenDSSDirectException CktElement.Open(0, 0)
+@test_throws OpenDSSDirect.OpenDSSDirectException CktElement.Close(0, 0)
+@test_throws OpenDSSDirect.OpenDSSDirectException CktElement.IsOpen(0, 0)
+@test CktElement.Open(1, -1) === nothing
+@test CktElement.Close(1, -1) === nothing
+@test CktElement.IsOpen(1, 0) == false
 @test CktElement.NumProperties() == 38
 @test CktElement.HasSwitchControl() == false
 @test CktElement.HasVoltControl() == false


### PR DESCRIPTION
Update the engine to DSS C-API v0.14.3, mostly due to an issue found in the CktElement API:

> Fix 13+ years old bug in `Open`/`Close`/`IsOpen` -- the terminal parameter was being effectively ignored, applying the operations to the active terminal; also add check for valid terminal index.

The tests were updated to address the changes. The original test didn't actually use a valid state, but as most of the original API code, the functions ignored the error silently.
